### PR TITLE
fix: correctly generate initial bounds for region map

### DIFF
--- a/src/components/utilities/map/js/dynamic.js
+++ b/src/components/utilities/map/js/dynamic.js
@@ -52,9 +52,28 @@ maps.forEach(container => {
       }
     })
 
-    bounds = markers.map(marker => {
-      return marker.geometry.coordinates
+    // Hardcode a starting position based on the UK (inc. NI)
+    let latMin = 58.8329
+    let latMax = 49.8437
+    let lngMin = 1.8642
+    let lngMax = -8.7189
+    bounds = []
+    markers.forEach(marker => {
+      if (marker.geometry.coordinates[1] < latMin) {
+        latMin = marker.geometry.coordinates[1]
+      }
+      if (marker.geometry.coordinates[1] >= latMax) {
+        latMax = marker.geometry.coordinates[1]
+      }
+      if (marker.geometry.coordinates[0] < lngMin) {
+        lngMin = marker.geometry.coordinates[0]
+      }
+      if (marker.geometry.coordinates[0] >= lngMax) {
+        lngMax = marker.geometry.coordinates[0]
+      }
     })
+    bounds.push([lngMin, latMin])
+    bounds.push([lngMax, latMax])
   }
 
   const mapElement = new System.Map({


### PR DESCRIPTION
* should be a pair of co-ordinates, e.g. bottom left & top right
* this is not a very elegant implementation, but seems quick enough for our limited use case