### PR TITLE
feat: use green for wood count markers

### DIFF
--- a/src/components/utilities/map/js/config/steps.js
+++ b/src/components/utilities/map/js/config/steps.js
@@ -3,16 +3,16 @@ module.exports = {
   small: {
     at: 5,
     size: 20,
-    color: '#51bbd6' // blue
+    color: '#92a892' // blue
   },
   medium: {
     at: 10,
     size: 30,
-    color: '#f1f075' // yellow
+    color: '#92a892' // yellow
   },
   large: {
     at: 15,
     size: 40,
-    color: '#f28cb1' // red
+    color: '#92a892' // red
   }
 }

--- a/src/components/utilities/map/js/config/steps.js
+++ b/src/components/utilities/map/js/config/steps.js
@@ -3,16 +3,16 @@ module.exports = {
   small: {
     at: 5,
     size: 20,
-    color: '#92a892' // blue
+    color: '#92a892' // brand-map-hover green
   },
   medium: {
     at: 10,
     size: 30,
-    color: '#92a892' // yellow
+    color: '#92a892' // brand-map-hover green
   },
   large: {
     at: 15,
     size: 40,
-    color: '#92a892' // red
+    color: '#92a892' // brand-map-hover green
   }
 }


### PR DESCRIPTION
* Use `brand-map-hover` colour for cluster markers, after feedback from agents
* Not completely sold on this choice, gathering more feedback before merging
